### PR TITLE
Default KC groups adjustment

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.0
+current_version = 1.6.1
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rasenmaeher_api"
-version = "1.6.0"
+version = "1.6.1"
 description = "python-rasenmaeher-api"
 authors = [
     "Aciid <703382+Aciid@users.noreply.github.com>",

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,2 +1,2 @@
 """ python-rasenmaeher-api """
-__version__ = "1.6.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.6.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/rasenmaeher_api/kchelpers.py
+++ b/src/rasenmaeher_api/kchelpers.py
@@ -210,7 +210,7 @@ class KCClient:
             subgroups_by_name: Dict[str, Dict[str, Any]] = {
                 subgroup["name"]: subgroup for subgroup in group["subGroups"]
             }
-            subgrpname = f"{productname}_dflt"
+            subgrpname = f"{productname}_default"
             if subgrpname not in subgroups_by_name:
                 LOGGER.info("Creating KC group /{}/{}".format(productname, subgrpname))
                 new_id = await self.kcadmin.a_create_group({"name": subgrpname}, parent=group["id"])

--- a/src/rasenmaeher_api/kchelpers.py
+++ b/src/rasenmaeher_api/kchelpers.py
@@ -210,14 +210,16 @@ class KCClient:
             subgroups_by_name: Dict[str, Dict[str, Any]] = {
                 subgroup["name"]: subgroup for subgroup in group["subGroups"]
             }
-            subgrpname = f"{productname}_default"
-            if subgrpname not in subgroups_by_name:
-                LOGGER.info("Creating KC group /{}/{}".format(productname, subgrpname))
-                new_id = await self.kcadmin.a_create_group({"name": subgrpname}, parent=group["id"])
-                subgroups_by_name[subgrpname] = await self.kcadmin.a_get_group(new_id)
-                created = True
-            if self._product_initial_grps is None:
-                self._product_initial_grps = {}
-            self._product_initial_grps[productname] = subgroups_by_name[subgrpname]
+            for suffix in ("default", "admins"):
+                subgrpname = f"{productname}_{suffix}"
+                if subgrpname not in subgroups_by_name:
+                    LOGGER.info("Creating KC group /{}/{}".format(productname, subgrpname))
+                    new_id = await self.kcadmin.a_create_group({"name": subgrpname}, parent=group["id"])
+                    subgroups_by_name[subgrpname] = await self.kcadmin.a_get_group(new_id)
+                    created = True
+                if self._product_initial_grps is None:
+                    self._product_initial_grps = {}
+                if suffix == "default":
+                    self._product_initial_grps[productname] = subgroups_by_name[subgrpname]
         LOGGER.debug("Product initial KC groups: {}".format(self._product_initial_grps))
         return created

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -15,7 +15,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.6.0"
+    assert __version__ == "1.6.1"
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
make the default name more readable and auto-add "admins" group for each product. This group has **no** special meaning for RASENMAEHER, RM admins are **not** added to these KC groups automatically.