### PR TITLE
Catch exceptions when calling remote APIs in the background

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.6.2
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rasenmaeher_api"
-version = "1.6.1"
+version = "1.6.2"
 description = "python-rasenmaeher-api"
 authors = [
     "Aciid <703382+Aciid@users.noreply.github.com>",

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,2 +1,2 @@
 """ python-rasenmaeher-api """
-__version__ = "1.6.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.6.2"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/rasenmaeher_api/prodcutapihelpers.py
+++ b/src/rasenmaeher_api/prodcutapihelpers.py
@@ -84,7 +84,11 @@ async def _method_to_all_products(
     async def handle_one(name: str) -> Tuple[str, Optional[pydantic.BaseModel]]:
         """Do one call"""
         nonlocal url_suffix, methodname, respose_schema, data
-        return name, await _method_to_product(name, methodname, url_suffix, data, respose_schema)
+        try:
+            return name, await _method_to_product(name, methodname, url_suffix, data, respose_schema)
+        except Exception as exc:  # pylint: disable=W0718
+            LOGGER.exception(exc)
+            return name, None
 
     if not collect_responses:
         tma = TaskMaster.singleton()

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -15,7 +15,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.6.1"
+    assert __version__ == "1.6.2"
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
so even if one call fails the others have a chance to run