### PR TITLE
DRAFT: Make it possible for product integration APIs to enable admin privileges for themselves to another product

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rasenmaeher_api"
-version = "1.7.0"
+version = "1.8.0"
 description = "python-rasenmaeher-api"
 authors = [
     "Aciid <703382+Aciid@users.noreply.github.com>",

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.7.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.8.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.7.0"
+    assert __version__ == "1.8.0"
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
Example use case: MediaMTX integration needs to be able to talk to TAKServer API directly to manage feeds. For this takintegration needs to enable mediamtx itegration services mTLS cert as admin to TAKServer