### PR TITLE
feat: Build k8s-latest docker image on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 on:
     pull_request:
+    push:
+      branches:
+        - main
 
 jobs:
   versiontag:
@@ -16,6 +19,7 @@ jobs:
 
   test:
     runs-on: arc-runner-set
+    if: github.event_name == 'pull_request'
     permissions:
       contents: write
       pull-requests: write
@@ -69,17 +73,47 @@ jobs:
           check_name: 'JUnit report (local)'
 
   docker_builds:
+    name: Docker build and push
     runs-on: arc-runner-set
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: pvarki/rmapi
+          tags: |
+            type=raw,value=latest,enable=${{ is_default_branch }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build test target
-        run: docker build --target test -t rmapi:test .
-      - name: Build production target
-        run: docker build --target production -t rmapi:production .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: test
+          push: false
+      - name: Build and push production target
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## User-facing summary
Latest rmapi image is always available at `pvarki/rmapi:latest`

## Why It's Good for the Product (Release Goal)
No need to build manually
