### PR TITLE
fix: decode PEM and get status properly

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.17.0+260523"
+current_version = "1.17.1+260603"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rasenmaeher_api"
-version = "1.17.0+260523"
+version = "1.17.1+260603"
 description = "python-rasenmaeher-api"
 authors = [
     { name = "Aciid", email = "703382+Aciid@users.noreply.github.com" },

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.17.0+260523"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.17.1+260603"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/src/rasenmaeher_api/cert/cert_manager/private.py
+++ b/src/rasenmaeher_api/cert/cert_manager/private.py
@@ -208,12 +208,13 @@ async def sign_csr(csr: str, bundle: bool = True) -> str:
             f"CertificateRequest {namespace}/{name} did not issue a certificate within {settings.cert_manager_timeout}s"
         ) from exc
 
+    certificate_request = await _get_cr(name, namespace)
     if certificate_request.status is None:
         raise RuntimeError("certificate request has no status")
     if certificate_request.status.certificate is None:
         raise RuntimeError("certificate request status has no certificate")
 
-    cert_pem: str = certificate_request.status.certificate
+    cert_pem = base64.b64decode(certificate_request.status.certificate).decode("utf-8")
 
     if bundle:
         ca_pem = await get_ca()

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.17.0+260523"
+    assert __version__ == "1.17.1+260603"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -1914,7 +1914,7 @@ wheels = [
 
 [[package]]
 name = "rasenmaeher-api"
-version = "1.17.0+260523"
+version = "1.17.1+260603"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## User-facing summary
Fixed issues with new cloudcoil wait flow, the object is not updated via the wait command, so it needs to be updated via a get. Additionally, the PEM file is encoded so needs to be decoded before being used.

## Why It's Good for the Product (Release Goal)
- Makes the product work as expected
