### PR TITLE
fix: rename validity header to Validity-Secret instead of X-Validity-…

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.17.1+260603"
+current_version = "1.17.2+260603"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rasenmaeher_api"
-version = "1.17.1+260603"
+version = "1.17.2+260603"
 description = "python-rasenmaeher-api"
 authors = [
     { name = "Aciid", email = "703382+Aciid@users.noreply.github.com" },

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.17.1+260603"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.17.2+260603"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/src/rasenmaeher_api/web/api/internal/callsign_validity.py
+++ b/src/rasenmaeher_api/web/api/internal/callsign_validity.py
@@ -17,7 +17,7 @@ Wire protocol:
     -> 400 if body is malformed
 
 Auth: if ``RM_CALLSIGN_VALIDITY_SECRET`` is set, the client must send a
-matching ``X-Validity-Secret`` header. Otherwise the endpoint is open
+matching ``Validity-Secret`` header. Otherwise the endpoint is open
 (suitable for in-cluster-only Service exposure).
 
 Note: this used to be a websocket endpoint, but Traefik's Yaegi interpreter
@@ -78,10 +78,10 @@ async def _is_valid(callsign: str) -> bool:
 @router.post("/check", response_model=CheckResponse)
 async def callsign_validity_check(
     req: CheckRequest,
-    x_validity_secret: Optional[str] = Header(default=None, alias="X-Validity-Secret"),
+    validity_secret: Optional[str] = Header(default=None, alias="Validity-Secret"),
 ) -> CheckResponse:
     """Return whether the given callsign is currently valid."""
-    _check_secret(x_validity_secret)
+    _check_secret(validity_secret)
     callsign = req.callsign.strip()
     if not callsign:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="callsign must be non-empty")

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.17.1+260603"
+    assert __version__ == "1.17.2+260603"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -1914,7 +1914,7 @@ wheels = [
 
 [[package]]
 name = "rasenmaeher-api"
-version = "1.17.1+260603"
+version = "1.17.2+260603"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## User-facing summary
Rename header to remove the legacy X- prefix

## Why It's Good for the Product (Release Goal)
Aligned with modern conventions

## Any Other You'd Like to Mention
No