### PR TITLE
Cr naming fix

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.17.2+260603"
+current_version = "1.17.3+260609"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rasenmaeher_api"
-version = "1.17.2+260603"
+version = "1.17.3+260609"
 description = "python-rasenmaeher-api"
 authors = [
     { name = "Aciid", email = "703382+Aciid@users.noreply.github.com" },

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.17.2+260603"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.17.3+260609"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/src/rasenmaeher_api/cert/cert_manager/names.py
+++ b/src/rasenmaeher_api/cert/cert_manager/names.py
@@ -2,17 +2,20 @@
 
 import hashlib
 import re
+from typing import Optional
 
 
-def cr_name(callsign: str) -> str:
+def cr_name(csr: str, callsign: Optional[str]) -> str:
     """Derive a Kubernetes resource name for a callsign's CertificateRequest.
 
     Callsigns can include characters outside the k8s ``[a-z0-9-]{1,253}`` set,
-    so we slugify and append a stable hash to guarantee uniqueness even when
-    sanitization would otherwise collide.
+    so we slugify and append a hash generated from the certificate signing
+    request to ensure uniqueness.
     """
-    slug = re.sub(r"[^a-z0-9-]", "-", callsign.lower()).strip("-")[:40]
-    digest = hashlib.sha256(callsign.encode("utf-8")).hexdigest()[:10]
+    identifier: str = callsign or "anon"
+
+    slug = re.sub(r"[^a-z0-9-]", "-", identifier.lower()).strip("-")[:40]
+    digest = hashlib.sha256(csr.encode("utf-8")).hexdigest()[:10]
     return "-".join(filter(None, ("rm", slug, digest)))
 
 

--- a/src/rasenmaeher_api/cert/cert_manager/private.py
+++ b/src/rasenmaeher_api/cert/cert_manager/private.py
@@ -7,7 +7,6 @@ Traefik callsign-validity plugin), so the revoke functions only best-effort
 clean up the CR.
 """
 
-import hashlib
 from typing import List, Literal, Tuple, Union, Any, Optional, cast
 from pathlib import Path
 import base64
@@ -191,7 +190,7 @@ async def sign_csr(csr: str, bundle: bool = True) -> str:
     """
     settings = RMSettings.singleton()
     cn = _csr_common_name(csr)
-    name = cr_name(cn) if cn else f"rm-anon-{hashlib.sha256(csr.encode()).hexdigest()[:10].lower()}"
+    name = cr_name(csr, cn)
     namespace = settings.cert_manager_namespace
     csr_b64 = _csr_pem_to_b64(csr)
 

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.17.2+260603"
+    assert __version__ == "1.17.3+260609"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -1914,7 +1914,7 @@ wheels = [
 
 [[package]]
 name = "rasenmaeher-api"
-version = "1.17.2+260603"
+version = "1.17.3+260609"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## User-facing summary
Use CSR to create the name for the Certificate request resource, to ensure no name collision. This is needed for tak.

## Why It's Good for the Product (Release Goal)
- Tak starts normally

## Additional info
- Tested via the PR published image and through devspace