### PR TITLE
chore: update libpvarki version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.17.7+260626"
+current_version = "1.17.8+260702"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rasenmaeher_api"
-version = "1.17.7+260626"
+version = "1.17.8+260702"
 description = "python-rasenmaeher-api"
 authors = [
     { name = "Aciid", email = "703382+Aciid@users.noreply.github.com" },

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.17.7+260626"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.17.8+260702"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.17.7+260626"
+    assert __version__ == "1.17.8+260702"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -1000,7 +1000,7 @@ wheels = [
 
 [[package]]
 name = "libpvarki"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://nexus.dev.pvarki.fi/repository/pypilocal/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1011,9 +1011,9 @@ dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://nexus.dev.pvarki.fi/repository/pypilocal/packages/libpvarki/2.2.0/libpvarki-2.2.0.tar.gz", hash = "sha256:202d8a33991147e56b0ac46d3290dd24e1cd028842bf519f7cdecf524c047242" }
+sdist = { url = "https://nexus.dev.pvarki.fi/repository/pypilocal/packages/libpvarki/2.2.1/libpvarki-2.2.1.tar.gz", hash = "sha256:163e4e4a1b2bf9571fd9ad5bb27afec6e576fe59947788bf16b83e834fe80613" }
 wheels = [
-    { url = "https://nexus.dev.pvarki.fi/repository/pypilocal/packages/libpvarki/2.2.0/libpvarki-2.2.0-py3-none-any.whl", hash = "sha256:ce6ddeca0079b21ce85d0b6974781af102aca559f7c6c7e2f3a7335073e7fbb2" },
+    { url = "https://nexus.dev.pvarki.fi/repository/pypilocal/packages/libpvarki/2.2.1/libpvarki-2.2.1-py3-none-any.whl", hash = "sha256:a8130e838046dbba99cd83eb39126001fb8e7da872f0c9f969d514a38f9968ad" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1936,7 +1936,7 @@ wheels = [
 
 [[package]]
 name = "rasenmaeher-api"
-version = "1.17.7+260626"
+version = "1.17.8+260702"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## User-Facing Summary
Updated libpvarki to a version that supports linkerd headers

## Why It's Good for the Product (Release Goal)
- Can use this for linkerd in k8s

## Anything Else You'd Like to Mention
- Open word
