### PR TITLE
Fix/cert manager

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.17.6+260613"
+current_version = "1.17.7+260626"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .idea
 
 *.ipynb
-
+.devspace
 
 # ci artefacts
 pytest*.xml

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,0 +1,32 @@
+version: v2beta1
+name: rasenmaeher-api
+
+images:
+  rmapi:
+    image: ghcr.io/pvarki/rasenmaeher-api
+    dockerfile: ./Dockerfile
+    context: ./
+    target: devel_shell
+    skipPush: true
+    buildKit: {}
+
+pipelines:
+  dev: |-
+    build_images --all
+    start_dev --all
+
+dev:
+  rmapi:
+    labelSelector:
+      app: rmapi
+    namespace: opendefence-system
+    container: rmapi
+    devImage: ${runtime.images.rmapi}
+    command:
+      - /bin/bash
+      - -lc
+      - source /container-init.sh && uv sync --frozen && uv run uvicorn --host 0.0.0.0 --port 8000 --log-level debug --factory rasenmaeher_api.web.application:get_app --reload
+    sync:
+      - path: ./src:/app/src
+      - path: ./docker:/app/docker
+    logs: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rasenmaeher_api"
-version = "1.17.6+260613"
+version = "1.17.7+260626"
 description = "python-rasenmaeher-api"
 authors = [
     { name = "Aciid", email = "703382+Aciid@users.noreply.github.com" },

--- a/src/rasenmaeher_api/__init__.py
+++ b/src/rasenmaeher_api/__init__.py
@@ -1,3 +1,3 @@
 """python-rasenmaeher-api"""
 
-__version__ = "1.17.6+260613"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.17.7+260626"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/src/rasenmaeher_api/cert/cert_manager/chain.py
+++ b/src/rasenmaeher_api/cert/cert_manager/chain.py
@@ -1,0 +1,32 @@
+"""Assemble a lean cert chain matching CFSSL's ``flavor=optimal`` bundle.
+
+cert-manager hands us PEM blobs (the issued cert plus the trust bundle) that,
+contain duplicate intermediates and the self-signed root. CFSSL's bundler
+dedupes and drops the root for us; this reproduces that shape so both
+backends yield identical PFX/bundle output.
+"""
+
+from typing import List, Set
+
+import cryptography.x509
+from cryptography.hazmat.primitives import hashes, serialization
+
+
+def lean_chain(*pem_blobs: str) -> str:
+    """Leaf first, then unique intermediate CAs; deduplicated by fingerprint
+    and with any self-signed root removed. Empty/blank inputs are ignored."""
+    certs: List[cryptography.x509.Certificate] = []
+    for blob in pem_blobs:
+        if blob and blob.strip():
+            certs.extend(cryptography.x509.load_pem_x509_certificates(blob.encode("utf-8")))
+    seen: Set[bytes] = set()
+    ordered: List[cryptography.x509.Certificate] = []
+    for cert in certs:
+        fingerprint = cert.fingerprint(hashes.SHA256())
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        if cert.subject == cert.issuer:  # drop root
+            continue
+        ordered.append(cert)
+    return b"".join(cert.public_bytes(serialization.Encoding.PEM) for cert in ordered).decode("utf-8")

--- a/src/rasenmaeher_api/cert/cert_manager/private.py
+++ b/src/rasenmaeher_api/cert/cert_manager/private.py
@@ -20,6 +20,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 
 from ...rmsettings import RMSettings
 from .base import CertManagerError
+from .chain import lean_chain
 from .names import cr_name
 from .public import get_ca
 
@@ -216,8 +217,9 @@ async def sign_csr(csr: str, bundle: bool = True) -> str:
     cert_pem = base64.b64decode(certificate_request.status.certificate).decode("utf-8")
 
     if bundle:
-        ca_pem = await get_ca()
-        cert_pem = cert_pem.rstrip("\n") + "\n" + ca_pem
+        cert_pem = lean_chain(cert_pem, await get_ca())
+    else:
+        cert_pem = lean_chain(cert_pem)
     return cert_pem
 
 

--- a/src/rasenmaeher_api/cert/cert_manager/public.py
+++ b/src/rasenmaeher_api/cert/cert_manager/public.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from ...rmsettings import RMSettings
 from .base import CertManagerError
+from .chain import lean_chain
 
 
 LOGGER = logging.getLogger(__name__)
@@ -46,8 +47,5 @@ async def get_crl() -> bytes:
 
 
 async def get_bundle(cert: str) -> str:
-    """Return cert concatenated with the CA bundle."""
-    ca_pem = await get_ca()
-    if not cert.endswith("\n"):
-        cert = cert + "\n"
-    return cert + ca_pem
+    """Return cert plus the issuing chain, deduplicated and root-stripped."""
+    return lean_chain(cert, await get_ca())

--- a/tests/test_rasenmaeher_api.py
+++ b/tests/test_rasenmaeher_api.py
@@ -16,7 +16,7 @@ from rasenmaeher_api.rmsettings import RMSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.17.6+260613"
+    assert __version__ == "1.17.7+260626"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/uv.lock
+++ b/uv.lock
@@ -1936,7 +1936,7 @@ wheels = [
 
 [[package]]
 name = "rasenmaeher-api"
-version = "1.17.6+260613"
+version = "1.17.7+260626"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## User-Facing Summary
- Cert-manager backends `.pfx` output to match cfssl backends `flavor=optimal`.
- Added devspace.yaml for k8s

## Why It's Good for the Product (Release Goal)
- Both backends produce similar output
- Browsers don't fill their authorities so quickly from certificates.
- Easy k8s development

## Anything Else You'd Like to Mention
- Cert-manager backend produced `.pfx` had the issued certificate + 2 x intermediate + root, now matches cfssl with issued certificate + intermediate.
